### PR TITLE
bugfix: shut down nRF52820 and turn off LED when USB disconnected

### DIFF
--- a/applications/ifmcu_firmware/src/main.c
+++ b/applications/ifmcu_firmware/src/main.c
@@ -15,6 +15,8 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/usb/bos.h>
 #include <zephyr/usb/msos_desc.h>
+#include <zephyr/sys/poweroff.h>
+#include <hal/nrf_power.h>
 #include <zephyr/dap/dap_link.h>
 
 #include <zephyr/usb/usb_device.h>
@@ -23,6 +25,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
+#include "led_state.h"
 #include "msosv2.h"
 
 DAP_LINK_CONTEXT_DEFINE(ifmcu_dap_ctx, DEVICE_DT_GET_ONE(zephyr_swdp_gpio));
@@ -46,6 +49,8 @@ static void ifmcu_usbd_msg_cb(struct usbd_context *const ctx, const struct usbd_
 		if (usbd_disable(ctx)) {
 			LOG_ERR("Failed to disable device support");
 		}
+		set_all_leds_off();
+		sys_poweroff();
 		break;
 
 	case USBD_MSG_RESUME:
@@ -108,6 +113,13 @@ int main(void)
 	if (ret) {
 		LOG_ERR("Failed to initialize device support");
 		return ret;
+	}
+
+	/* No USB cable at boot — go straight to SYSTEM OFF.  Charger and
+	 * settings are already initialised by SYS_INIT before main(). */
+	if (!nrf_power_usbregstatus_vbusdet_get(NRF_POWER)) {
+		set_all_leds_off();
+		sys_poweroff();
 	}
 
 	ret = usbd_enable(ifmcu_usbd);

--- a/applications/ifmcu_firmware/src/main.c
+++ b/applications/ifmcu_firmware/src/main.c
@@ -28,6 +28,13 @@ LOG_MODULE_REGISTER(main);
 #include "led_state.h"
 #include "msosv2.h"
 
+static void enter_system_off(void)
+{
+	SCB->SCR &= ~SCB_SCR_SEVONPEND_Msk;
+	__DSB();
+	sys_poweroff();
+}
+
 DAP_LINK_CONTEXT_DEFINE(ifmcu_dap_ctx, DEVICE_DT_GET_ONE(zephyr_swdp_gpio));
 
 const struct device *const uart_bridge = DEVICE_DT_GET_ONE(zephyr_uart_bridge);
@@ -50,7 +57,7 @@ static void ifmcu_usbd_msg_cb(struct usbd_context *const ctx, const struct usbd_
 			LOG_ERR("Failed to disable device support");
 		}
 		set_all_leds_off();
-		sys_poweroff();
+		enter_system_off();
 		break;
 
 	case USBD_MSG_RESUME:
@@ -115,11 +122,9 @@ int main(void)
 		return ret;
 	}
 
-	/* No USB cable at boot — go straight to SYSTEM OFF.  Charger and
-	 * settings are already initialised by SYS_INIT before main(). */
 	if (!nrf_power_usbregstatus_vbusdet_get(NRF_POWER)) {
 		set_all_leds_off();
-		sys_poweroff();
+		enter_system_off();
 	}
 
 	ret = usbd_enable(ifmcu_usbd);


### PR DESCRIPTION
Hi

I'm building an open-source vehicle tracker that uses the Connect Kit (see: https://l0destar.com) and believe I have identified a bug in the nRF52820 firmware.

My prototypes have a sleep current of 120 µA but I noticed that if I connect the USB interface and disconnect it again this jumps to around 2mA and the green LED on the Connect Kit stays on when it was off before. It seems that after VBUS removal the USB stack is disabled but the UART bridge peripheral keeps HFCLK running (~2mA), and the green status LED stays lit (~300µA). The chip stays in this state indefinitely.

This is a problem for my boards because they're intended to be hardwired into vehicles and so minimal sleep current is critical.

The patch adds set_all_leds_off() + sys_poweroff() to two paths in main.c: the USBD_MSG_VBUS_REMOVED callback, and a VBUS check at the top of main() for the case where the board boots without a USB cable. In SYSTEM OFF the nRF52820 draws ~0.3µA and wakes automatically on VBUS detect, rebooting with full functionality (CMSIS-DAP, UART bridge, shell, charger).

In my testing this completely resolves the issue, after unplugging the USB and letting the device go back to sleep its current is once again 120 µA. Reconnecting the cable still works normally.

Cheers,
Mark

